### PR TITLE
execute deletion of trackedentityaudit

### DIFF
--- a/resources/sql/delete_orgunit_with_data.sql
+++ b/resources/sql/delete_orgunit_with_data.sql
@@ -45,6 +45,7 @@ EXECUTE 'DELETE FROM programinstance WHERE organisationunitid = $1 OR trackedent
 --delete all data still connected to trackedentityinstances based on trackedentityinstance orgunit
 EXECUTE 'DELETE FROM trackedentityattributevalue WHERE trackedentityinstanceid IN(SELECT trackedentityinstanceid from trackedentityinstance where organisationunitid = $1) ' USING organisationunitid;
 EXECUTE 'DELETE FROM trackedentityattributevalueaudit WHERE trackedentityinstanceid IN(SELECT trackedentityinstanceid from trackedentityinstance where organisationunitid = $1) ' USING organisationunitid;
+EXECUTE 'DELETE FROM trackedentityaudit WHERE trackedentityinstanceid IN(SELECT trackedentityinstanceid from trackedentityinstance where organisationunitid = $1) ' USING organisationunitid;
 EXECUTE 'DELETE FROM trackedentityinstance WHERE organisationunitid = $1 ' USING organisationunitid;
 
 EXECUTE 'DELETE FROM userdatavieworgunits WHERE organisationunitid = $1 ' USING organisationunitid;

--- a/resources/sql/delete_orgunittree_with_data.sql
+++ b/resources/sql/delete_orgunittree_with_data.sql
@@ -41,6 +41,7 @@ EXECUTE 'DELETE FROM programinstance WHERE organisationunitid = $1 OR trackedent
 --delete all data still connected to trackedentityinstances based on trackedentityinstance orgunit
 EXECUTE 'DELETE FROM trackedentityattributevalue WHERE trackedentityinstanceid IN(SELECT trackedentityinstanceid from trackedentityinstance where organisationunitid = $1) ' USING organisationunitid;
 EXECUTE 'DELETE FROM trackedentityattributevalueaudit WHERE trackedentityinstanceid IN(SELECT trackedentityinstanceid from trackedentityinstance where organisationunitid = $1) ' USING organisationunitid;
+EXECUTE 'DELETE FROM trackedentityaudit WHERE trackedentityinstanceid IN(SELECT trackedentityinstanceid from trackedentityinstance where organisationunitid = $1) ' USING organisationunitid;
 EXECUTE 'DELETE FROM trackedentityinstance WHERE organisationunitid = $1 ' USING organisationunitid;
 
 EXECUTE 'DELETE FROM userdatavieworgunits WHERE organisationunitid = $1 ' USING organisationunitid;


### PR DESCRIPTION
Table `relationship` might also be left with orphaned rows if not removed:

`EXECUTE 'DELETE FROM relationship WHERE trackedentityinstanceaid IN(SELECT trackedentityinstanceid from trackedentityinstance where organisationunitid = $1) OR trackedentityinstancebid IN(SELECT trackedentityinstanceid from trackedentityinstance where organisationunitid = $1)' USING organisationunitid;`
