### PR TITLE
Fix userroleprogram table name to program_userroles.

### DIFF
--- a/resources/sql/upgrade-229.sql
+++ b/resources/sql/upgrade-229.sql
@@ -83,12 +83,12 @@ loop
 			end if;
 		end loop;
 	end if;
-	if exists ( select 1 from userroleprogram urp where urp.userroleid = role.userroleid )
+	if exists ( select 1 from program_userroles urp where urp.userroleid = role.userroleid )
 	then 
 		insert into usergroup (usergroupid, name, uid, code, lastupdated, created, userid, publicaccess, lastupdatedby)
 		values ( nextval('hibernate_sequence'::regclass), '_PROGRAM_' || role.name, uid(), null,null,now(), role.userid, 'rw------',null )
 		returning usergroup.usergroupid into curUserGroupId;
-		for roleProgram in select * from userroleprogram
+		for roleProgram in select * from program_userroles
 		loop 
 			insert into usergroupaccess ( usergroupaccessid, access, usergroupid )
 			values ( nextval('hibernate_sequence'::regclass), 'r-rw----', curUserGroupId )


### PR DESCRIPTION
Currently code is using table `program_userroles`.
`userroleprogram` is a legacy table and is not being used anywhere in codes. It should be dropped in a separate clean up script.