### PR TITLE
Update package_exporter.py

### DIFF
--- a/tools/dhis2-package-exporter/package_exporter.py
+++ b/tools/dhis2-package-exporter/package_exporter.py
@@ -1114,7 +1114,7 @@ def main():
             'constants', 'documents', 'attributes',
             'dataEntryForms', 'sections', 'dataSets', # Some programs, like HIV, have dataSets
             'dataElements', 'dataElementGroups',
-            'validationRules', 'validationRuleGroups'
+            'validationRules', 'validationRuleGroups',
             'jobConfigurations',
             'predictors', 'predictorGroups',
             'trackedEntityAttributes', 'trackedEntityTypes', 'trackedEntityInstanceFilters',


### PR DESCRIPTION
A comma missing in the list of elements to process gives this
* INFO  2022-03-11 09:44:16,083  ------------ validationRuleGroupsjobConfigurations ------------ [package_exporter:1343]
Traceback (most recent call last):
  File "dhis2-utils/tools/dhis2-package-exporter/package_exporter.py", line 2264, in <module>
    package_file = main()
  File "dhis2-utils/tools/dhis2-package-exporter/package_exporter.py", line 1389, in main
    elif 'code:$like' in metadata_filters[metadata_type]:
KeyError: 'validationRuleGroupsjobConfigurations'