### PR TITLE
Bug in legendSets for DSH package type

### DIFF
--- a/tools/dhis2-package-exporter/package_exporter.py
+++ b/tools/dhis2-package-exporter/package_exporter.py
@@ -2086,6 +2086,9 @@ def main():
                     if 'indicatorGroupSet' in indGroup:
                         indicatorGroupSets_uids.append(indGroup['indicatorGroupSet']['id'])
                 metadata_filters["indicatorGroupSets"] = "id:in:[" + ','.join(indicatorGroupSets_uids) + "]"
+            elif metadata_type == 'indicatorTypes':
+                # Update legendSets filter (especially important for AGG and GEN packages)
+                metadata_filters["legendSets"] = "id:in:[" + ','.join(legendSets_uids) + "]" 
             elif metadata_type == 'dataElementGroups':
                 dataElements_in_package = json_extract_nested_ids(metaobject, 'dataElements')
                 metadata_filters["dataElements"] = "id:in:[" + ','.join(dataElements_in_package) + "]"


### PR DESCRIPTION
The filter for legendSets is updated when we reach optionGroups metadata but this metadata type is not included in DHS package type, so the filter is never updated. Thus we are updating it after all the legendSets UIDs have been harvested