### PR TITLE
Bug: warning for TEAs missing interpreted as error

### DIFF
--- a/tools/dhis2-package-exporter/package_exporter.py
+++ b/tools/dhis2-package-exporter/package_exporter.py
@@ -1626,7 +1626,7 @@ def main():
                     if len(diff_data_dimension) > 0:
                         logger.warning("Data dimension in analytics use TEAs not included in the package: "
                                        + str(diff_data_dimension) + "... Adding them")
-                        total_errors += 1
+
                         trackedEntityAttributes_in_data_dimension = get_metadata_element(metadata_type, "id:in:[" + ','.join(
                             diff_data_dimension) + "]")
                         trackedEntityAttributes_in_data_dimension = check_sharing(trackedEntityAttributes_in_data_dimension)


### PR DESCRIPTION
When checking if TEAs used in analytics are part of the package, it gives a warning but the script exits with 1