### PR TITLE
Make it compatible with 2.36

### DIFF
--- a/resources/sql/delete_orgunittree_with_data.sql
+++ b/resources/sql/delete_orgunittree_with_data.sql
@@ -53,7 +53,7 @@ CREATE TEMP TABLE IF NOT EXISTS temp1 (
 EXECUTE 'DELETE FROM chart_organisationunits WHERE organisationunitid = $1 ' USING organisationunitid;
 EXECUTE 'INSERT INTO temp1 SELECT chartid from chart_organisationunits where organisationunitid = $1 'USING organisationunitid;
 
-FOR resort_object IN SELECT objectid from temp1 LOOP
+FOR resort_object IN SELECT objectid FROM temp1 LOOP
 EXECUTE 'update chart_organisationunits set sort_order = -t.i
 from (select row_number() over (ORDER BY sort_order) as i, chartid, sort_order, organisationunitid
    from chart_organisationunits where chartid=$1 order by sort_order) t
@@ -67,7 +67,7 @@ EXECUTE 'TRUNCATE temp1';
 EXECUTE 'INSERT INTO temp1 SELECT DISTINCT reporttableid from reporttable_organisationunits where organisationunitid = $1 'USING organisationunitid;
 EXECUTE 'DELETE FROM reporttable_organisationunits WHERE organisationunitid = $1 ' USING organisationunitid;
 
-FOR resort_object IN SELECT objectid from temp1 LOOP
+FOR resort_object IN SELECT objectid FROM temp1 LOOP
 EXECUTE 'update reporttable_organisationunits set sort_order = -t.i
 from (select row_number() over (ORDER BY sort_order) as i, reporttableid, sort_order, organisationunitid
 from reporttable_organisationunits where reporttableid=$1 order by sort_order) t
@@ -82,7 +82,7 @@ EXECUTE 'TRUNCATE temp1';
 EXECUTE 'DELETE FROM visualization_organisationunits WHERE organisationunitid = $1 ' USING organisationunitid;
 EXECUTE 'INSERT INTO temp1 SELECT visualizationid from visualization_organisationunits where organisationunitid = $1 'USING organisationunitid;
 
-FOR resort_object IN SELECT objectid from temp1 LOOP
+FOR resort_object IN SELECT objectid FROM temp1 LOOP
 EXECUTE 'update visualization_organisationunits set sort_order = -t.i
 from (select row_number() over (ORDER BY sort_order) as i, visualizationid, sort_order, organisationunitid
    from visualization_organisationunits where visualizationid=$1 order by sort_order) t
@@ -95,7 +95,7 @@ EXECUTE 'TRUNCATE temp1';
 
 EXECUTE 'INSERT INTO temp1 SELECT DISTINCT mapviewid from mapview_organisationunits where organisationunitid = $1 'USING organisationunitid;
 EXECUTE 'DELETE FROM mapview_organisationunits WHERE organisationunitid = $1 ' USING organisationunitid;
-FOR resort_object IN SELECT objectid from temp1 LOOP
+FOR resort_object IN SELECT objectid FROM temp1 LOOP
 EXECUTE 'update mapview_organisationunits set sort_order = -t.i
 from (select row_number() over (ORDER BY sort_order) as i,mapviewid, sort_order, organisationunitid
 from mapview_organisationunits where mapviewid=$1 order by sort_order) t
@@ -109,7 +109,7 @@ EXECUTE 'TRUNCATE temp1';
 EXECUTE 'INSERT INTO temp1 SELECT DISTINCT eventchartid from eventchart_organisationunits where organisationunitid = $1 'USING organisationunitid;
 EXECUTE 'DELETE FROM eventchart_organisationunits WHERE organisationunitid = $1 ' USING organisationunitid;
 
-FOR resort_object IN SELECT objectid from temp1 LOOP
+FOR resort_object IN SELECT objectid FROM temp1 LOOP
 EXECUTE 'update eventchart_organisationunits set sort_order = -t.i
 from (select row_number() over (ORDER BY sort_order) as i, eventchartid, sort_order, organisationunitid
     from eventchart_organisationunits where eventchartid=$1 order by sort_order) t
@@ -122,7 +122,7 @@ EXECUTE 'TRUNCATE temp1';
 
 EXECUTE 'INSERT INTO temp1 SELECT DISTINCT eventreportid from eventreport_organisationunits where organisationunitid = $1 'USING organisationunitid;
 EXECUTE 'DELETE FROM eventreport_organisationunits WHERE organisationunitid = $1 ' USING organisationunitid;
-FOR resort_object IN SELECT objectid from temp1 LOOP
+FOR resort_object IN SELECT objectid FROM temp1 LOOP
 EXECUTE 'UPDATE eventreport_organisationunits set sort_order = -t.i
 from (select row_number() over (ORDER BY sort_order) as i, eventreportid, sort_order, organisationunitid
     from eventreport_organisationunits where eventreportid=$1 order by sort_order) t
@@ -143,7 +143,7 @@ $$ LANGUAGE plpgsql VOLATILE;
 
 EXECUTE 'INSERT INTO temp1 SELECT DISTINCT eventvisualizationid from eventvisualization_organisationunits where organisationunitid = $1 'USING organisationunitid;
 EXECUTE 'DELETE FROM eventvisualization_organisationunits WHERE organisationunitid = $1 ' USING organisationunitid;
-FOR resort_object IN SELECT objectid from temp1 LOOP
+FOR resort_object IN SELECT objectid FROM temp1 LOOP
 EXECUTE 'UPDATE eventvisualization_organisationunits set sort_order = -t.i
 from (select row_number() over (ORDER BY sort_order) as i, eventvisualizationid, sort_order, organisationunitid
     from eventvisualization_organisationunits where eventvisualizationid=$1 order by sort_order) t

--- a/resources/sql/delete_orgunittree_with_data.sql
+++ b/resources/sql/delete_orgunittree_with_data.sql
@@ -23,8 +23,6 @@ EXECUTE 'DELETE FROM minmaxdataelement WHERE sourceid = $1 ' USING organisationu
 EXECUTE 'DELETE FROM orgunitgroupmembers WHERE organisationunitid = $1 ' USING organisationunitid;
 
 --delete all data from programstageinstance and down based on first programstageinstance orgunit then programinstance orgunit and lastly trackedentityinstance orgunit
-EXECUTE 'DELETE FROM trackedentityattributevalueaudit WHERE trackedentityinstanceid IN (SELECT trackedentityinstanceid FROM trackedentityinstance WHERE organisationunitid = $1) '
-USING organisationunitid;
 EXECUTE 'DELETE FROM programstageinstancecomments WHERE programstageinstanceid IN (SELECT programstageinstanceid FROM programstageinstance WHERE organisationunitid = $1 OR programinstanceid IN (SELECT programinstanceid FROM programinstance WHERE organisationunitid = $1 OR trackedentityinstanceid IN (SELECT trackedentityinstanceid FROM trackedentityinstance WHERE organisationunitid = $1))) '
 USING organisationunitid;
 EXECUTE 'DELETE FROM programstageinstance_outboundsms WHERE programstageinstanceid IN (SELECT programstageinstanceid FROM programstageinstance WHERE organisationunitid = $1 OR programinstanceid IN (SELECT programinstanceid FROM programinstance WHERE organisationunitid = $1 OR trackedentityinstanceid IN (SELECT trackedentityinstanceid FROM trackedentityinstance WHERE organisationunitid = $1))) '

--- a/resources/sql/delete_orgunittree_with_data.sql
+++ b/resources/sql/delete_orgunittree_with_data.sql
@@ -131,14 +131,6 @@ EXECUTE 'update eventreport_organisationunits set sort_order = -(sort_order+1) w
 END LOOP;
 EXECUTE 'TRUNCATE temp1';
 
-EXECUTE 'DELETE FROM organisationunit WHERE organisationunitid = $1 ' USING organisationunitid;
-
-RETURN 1;
-
-END;
-$$ LANGUAGE plpgsql VOLATILE;
-
-
 -- eventvisualization_organisationunits
 
 EXECUTE 'INSERT INTO temp1 SELECT DISTINCT eventvisualizationid from eventvisualization_organisationunits where organisationunitid = $1 'USING organisationunitid;

--- a/resources/sql/delete_orgunittree_with_data.sql
+++ b/resources/sql/delete_orgunittree_with_data.sql
@@ -23,8 +23,6 @@ EXECUTE 'DELETE FROM minmaxdataelement WHERE sourceid = $1 ' USING organisationu
 EXECUTE 'DELETE FROM orgunitgroupmembers WHERE organisationunitid = $1 ' USING organisationunitid;
 
 --delete all data from programstageinstance and down based on first programstageinstance orgunit then programinstance orgunit and lastly trackedentityinstance orgunit
-EXECUTE 'DELETE FROM trackedentityattributevalue WHERE trackedentityinstanceid IN (SELECT trackedentityinstanceid FROM trackedentityinstance WHERE organisationunitid = $1) '
-USING organisationunitid;
 EXECUTE 'DELETE FROM trackedentityattributevalueaudit WHERE trackedentityinstanceid IN (SELECT trackedentityinstanceid FROM trackedentityinstance WHERE organisationunitid = $1) '
 USING organisationunitid;
 EXECUTE 'DELETE FROM programstageinstancecomments WHERE programstageinstanceid IN (SELECT programstageinstanceid FROM programstageinstance WHERE organisationunitid = $1 OR programinstanceid IN (SELECT programinstanceid FROM programinstance WHERE organisationunitid = $1 OR trackedentityinstanceid IN (SELECT trackedentityinstanceid FROM trackedentityinstance WHERE organisationunitid = $1))) '


### PR DESCRIPTION
Still need to add a query block for eventvisualization

For the moment, I corrected tables trackedentitydatavalue, trackedentitydatavalueaudit I removed the query for translations (translations are no longer in a separate table) Added a block to take care of references to visualization table

Something like this might be needed for higher versions: EXECUTE 'INSERT INTO temp1 SELECT DISTINCT eventvisualizationid from eventvisualization_organisationunits where organisationunitid = $1 'USING organisationunitid; EXECUTE 'DELETE FROM eventvisualization_organisationunits WHERE organisationunitid = $1 ' USING organisationunitid; FOR resort_object IN SELECT objectid from temp1 LOOP EXECUTE 'UPDATE eventvisualization_organisationunits set sort_order = -t.i from (select row_number() over (ORDER BY sort_order) as i, eventvisualizationid, sort_order, organisationunitid
    from eventvisualization_organisationunits where eventvisualizationid=$1 order by sort_order) t
where eventvisualization_organisationunits.organisationunitid = t.organisationunitid and eventvisualization_organisationunits.eventvisualizationid=$1' USING resort_object.objectid ; EXECUTE 'update eventvisualization_organisationunits set sort_order = -(sort_order+1) where eventvisualizationid=$1' USING resort_object.objectid ; END LOOP;
EXECUTE 'TRUNCATE temp1';