### PR TITLE
Fix bug with userGroup sharing

### DIFF
--- a/tools/dhis2-package-exporter/package_exporter.py
+++ b/tools/dhis2-package-exporter/package_exporter.py
@@ -1813,8 +1813,11 @@ def main():
                         # Add userGroups and check sharing
                         metadata['userGroups'] += new_userGroups
                         # Before calling check_and_apply_sharing, update the userGroup uids global variable
-                        userGroups_uids += new_userGroups_uids
-                        metadata['userGroups'] = check_and_apply_sharing(metadata['userGroups'], metadata_type)
+                        # userGroups_uids += new_userGroups_uids
+                        # for new_userGroup in new_userGroups:
+                        #     if new_userGroup['id'] not in userGroups_codes:
+                        #         userGroups_codes[new_userGroup['id']] = new_userGroup['code']
+                        # metadata['userGroups'] = check_and_apply_sharing(metadata['userGroups'], metadata_type)
 
             elif metadata_type == "validationNotificationTemplates":
                 # Check for userGroups used which are not included in the package


### PR DESCRIPTION
I took an easy approach for this.
user groups that are used for notifications will be added later on but the checks wont be carried out. These checks apply only to our standards sharing groups in any case.