### PR TITLE
DataSetElements check not working

### DIFF
--- a/tools/dhis2-package-exporter/package_exporter.py
+++ b/tools/dhis2-package-exporter/package_exporter.py
@@ -1172,8 +1172,8 @@ def main():
             'legendSets',  # used in indicators, optionGroups, programIndicators and trackedEntityAttributes
             'optionGroups', 'options', 'optionSets',
             'sqlViews', 'reports', 'constants', 'documents', 'attributes',
-            'dataEntryForms', 'sections', 'dataSets',  # Some programs, like HIV, have dataSets
             'dataElements', 'dataElementGroups',
+            'dataEntryForms', 'sections', 'dataSets',
             'validationNotificationTemplates', 'validationRules', 'validationRuleGroups',
             'jobConfigurations',
             'predictors', 'predictorGroups',


### PR DESCRIPTION
It is required to process dataSets before dataElements for Tracker and Event packages, same as it happens for AGG ones