### PR TITLE
Update VLOOKUP formula to catch multiple UIDs

### DIFF
--- a/tools/dhis2-metadata_flat_file_syncer/metadata_ff_syncer.py
+++ b/tools/dhis2-metadata_flat_file_syncer/metadata_ff_syncer.py
@@ -443,9 +443,9 @@ def apply_formatting_to_worksheet(worksheet, metadata_types_supported, worksheet
                 col_letter = gspread.utils.rowcol_to_a1(1, col_index + 2).split('1')[0]
                 rows = list()
                 for row_index in range(2, worksheet.row_count + 1):
-                    formula = "=iferror(VLOOKUP(" + col_letter + str(
-                        row_index) + ",{'" + the_worksheet + "'!$B$2:$B, '" + the_worksheet + "'!$A$2:$A}, 2, FALSE), \"\")"
-
+                    formula = "=iferror(TEXTJOIN(\", \", TRUE, FILTER('" + the_worksheet + "'!$A$2:$A, '" + the_worksheet + "'!$B$2:$B = " + col_letter + str(
+                        row_index) + ")), \"\")"
+                    
                     rows.append({
                         "values": [
                             {


### PR DESCRIPTION
From Pablo: When you have 2 programs and the programStages are having the same name, the FF is assigning the wrong programStage. This is coming because when we export the PR metadata, we're creating a list which is including only "unique" programstages names. For example:
You have
Program A - ProgramStage "Laboratory" (UID xxxxx)
Program B - ProgramStage "Laboratory" (UID yyyyy)
You export the PR and all PRs that are triggered for Program Stage "Laboratory" are getting the UID xxxxxx. Meaning that the PR for Program B are broken